### PR TITLE
fix(overlay-api): relative path

### DIFF
--- a/overlay-api/README.md
+++ b/overlay-api/README.md
@@ -35,7 +35,7 @@ The overlay service is an optional service and therefore it has to be loaded exp
 
 ```javascript
 var BpmnViewer = require('bpmn-js');
-var overlayModule = require('../../../diagram-js/lib/features/overlays');
+var overlayModule = require('diagram-js/features/overlays');
 
 var bpmnModules = BpmnViewer.prototype._modules.concat([ overlayModule ]);
 viewer = new BpmnViewer({ container: '#canvas', modules: bpmnModules});


### PR DESCRIPTION
the example should probably not use the relative path to the project but an absolute path. I am not 100% sure though the fix I am suggesting is correct (needs to be verified).
