### PR TITLE
Model property namespace added

### DIFF
--- a/properties-panel-extension/app/provider/magic/parts/SpellProps.js
+++ b/properties-panel-extension/app/provider/magic/parts/SpellProps.js
@@ -14,7 +14,7 @@ module.exports = function(group, element) {
       id : 'spell',
       description : 'Apply a black magic spell',
       label : 'Spell',
-      modelProperty : 'spell'
+      modelProperty : 'magic:spell'
     }));
   }
 };


### PR DESCRIPTION
In order to correctly use the spell property from the descriptor the namespace must be added. Same es in pull request #37.