### PR TITLE
spellProps invocation corrected

### DIFF
--- a/properties-panel-extension/README.md
+++ b/properties-panel-extension/README.md
@@ -82,9 +82,7 @@ function createMagicTabGroups(element, elementRegistry) {
   var blackMagicGroup = {
     id: 'black-magic',
     label: 'Black Magic',
-    entries: [
-      spellProps(blackMagicGroup, element);
-    ]
+    entries: []
   };
 
   // Add the spell props to the black magic group.


### PR DESCRIPTION
This line was definitely false since `spellProps` doesn't return anything and is invoked below aswell.