### PR TITLE
Fix JSHint error for minimap

### DIFF
--- a/minimap/Gruntfile.js
+++ b/minimap/Gruntfile.js
@@ -12,6 +12,12 @@ module.exports = function(grunt) {
   }
 
   grunt.initConfig({
+    jshint: {
+      all: ['app/**/*.js'],
+	  options: {
+		  esversion: 6
+	  }
+    },
     browserify: {
       options: {
         browserifyOptions: {
@@ -147,5 +153,6 @@ module.exports = function(grunt) {
     'watch'
   ]);
 
+  grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.registerTask('default', [ 'jshint', 'build' ]);
 };

--- a/minimap/package.json
+++ b/minimap/package.json
@@ -33,6 +33,7 @@
     "grunt-browserify": "^5.3.0",
     "grunt-contrib-connect": "~1.0.2",
     "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-less": "^2.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "load-grunt-tasks": "~3.5.0",


### PR DESCRIPTION
JSHint is not configured properly, leading to an error during `npm run all`. This should be fixed now.