### PR TITLE
Some fixes for a couple of examples

### DIFF
--- a/modeler/.gitignore
+++ b/modeler/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 public/app.bundled.js
 public/app.bundled.js.map
+public/*.eot
+public/*.svg
 public/vendor/
 tmp/

--- a/modeler/package.json
+++ b/modeler/package.json
@@ -31,11 +31,14 @@
   "license": "MIT",
   "devDependencies": {
     "cpx": "^1.5.0",
+    "css-loader": "^1.0.0",
     "eslint": "^5.0.1",
     "eslint-plugin-bpmn-io": "^0.5.3",
+    "file-loader": "^2.0.0",
     "npm-run-all": "^4.1.3",
     "raw-loader": "^0.5.1",
     "serve": "^9.2.0",
+    "style-loader": "^0.22.1",
     "webpack": "^4.15.1",
     "webpack-cli": "^3.0.8"
   },

--- a/modeler/public/app.js
+++ b/modeler/public/app.js
@@ -4,6 +4,8 @@ import BpmnModeler from 'bpmn-js/lib/Modeler';
 
 import diagramXML from '../resources/newDiagram.bpmn';
 
+import style from 'bpmn-js/dist/assets/diagram-js.css'; // eslint-disable-line no-unused-vars
+import icons from 'bpmn-font/dist/css/bpmn-embedded.css'; // eslint-disable-line no-unused-vars
 
 var container = $('#js-drop-zone');
 

--- a/modeler/public/css/app.css
+++ b/modeler/public/css/app.css
@@ -21,6 +21,7 @@ a:link {
 .content > div {
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .content > .message {

--- a/modeler/public/index.html
+++ b/modeler/public/index.html
@@ -1,9 +1,8 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>bpmn-js modeler demo</title>
 
-  <link rel="stylesheet" href="vendor/bpmn-js/assets/diagram-js.css" />
-  <link rel="stylesheet" href="vendor/bpmn-js/assets/bpmn-font/css/bpmn-embedded.css" />
   <link rel="stylesheet" href="css/app.css" />
 </head>
 <body>

--- a/modeler/webpack.config.js
+++ b/modeler/webpack.config.js
@@ -11,7 +11,15 @@ module.exports = {
       {
         test: /\.bpmn$/,
         use: 'raw-loader'
-      }
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.(eot|svg|ttf|woff)$/,
+        loader: 'file-loader',
+      },
     ]
   },
   mode: 'development',

--- a/properties-panel/app/index.html
+++ b/properties-panel/app/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="css/app.css" />
 </head>
 <body>
-  <div class="content" id="js-drop-zone">
+  <div class="content with-diagram" id="js-drop-zone">
 
     <div class="message intro">
       <div class="note">

--- a/properties-panel/app/index.js
+++ b/properties-panel/app/index.js
@@ -29,6 +29,7 @@ var bpmnModeler = new BpmnModeler({
     camunda: camundaModdleDescriptor
   }
 });
+container.removeClass('with-diagram');
 
 function createNewDiagram() {
   openDiagram(diagramXML);

--- a/properties-panel/styles/app.less
+++ b/properties-panel/styles/app.less
@@ -41,7 +41,7 @@ a:link {
       display: table-cell;
     }
 
-    .error {
+    &.error {
       .details {
         max-width: 500px;
         font-size: 12px;


### PR DESCRIPTION
Fixes 'modeler' build flaws (not working at all):
![before-modeler-palette](https://user-images.githubusercontent.com/2509642/44565415-328d8780-a792-11e8-8158-9dde267c9715.png)
and scrollbar:
![before-modeler-scrollbar](https://user-images.githubusercontent.com/2509642/44565417-37523b80-a792-11e8-95af-63d26b09c7da.png)
Fixes unnecessary palette twocolumnness:
![panel-palette](https://user-images.githubusercontent.com/2509642/44565420-3c16ef80-a792-11e8-90c7-c7e410e80c87.png)
And error pane styling:
![panel-error](https://user-images.githubusercontent.com/2509642/44565512-acbe0c00-a792-11e8-9f8b-09d1d8c32269.png)
