### PR TITLE
Bump deps

### DIFF
--- a/properties-panel-extension/app/provider/magic/MagicPropertiesProvider.js
+++ b/properties-panel-extension/app/provider/magic/MagicPropertiesProvider.js
@@ -18,7 +18,7 @@ import spellProps from './parts/SpellProps';
 
 // The general tab contains all bpmn relevant properties.
 // The properties are organized in groups.
-function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate) {
+function createGeneralTabGroups(element, bpmnFactory, canvas, elementRegistry, translate) {
 
   var generalGroup = {
     id: 'general',
@@ -26,7 +26,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate
     entries: []
   };
   idProps(generalGroup, element, translate);
-  nameProps(generalGroup, element, translate);
+  nameProps(generalGroup, element, bpmnFactory, canvas, translate);
   processProps(generalGroup, element, translate);
 
   var detailsGroup = {
@@ -53,7 +53,7 @@ function createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate
 }
 
 // Create the custom magic tab
-function createMagicTabGroups(element, elementRegistry) {
+function createMagicTabGroups(element) {
 
   // Create a group called "Black Magic".
   var blackMagicGroup = {
@@ -71,8 +71,8 @@ function createMagicTabGroups(element, elementRegistry) {
 }
 
 export default function MagicPropertiesProvider(
-    eventBus, bpmnFactory, elementRegistry,
-    translate) {
+    eventBus, bpmnFactory, canvas,
+    elementRegistry, translate) {
 
   PropertiesActivator.call(this, eventBus);
 
@@ -81,14 +81,14 @@ export default function MagicPropertiesProvider(
     var generalTab = {
       id: 'general',
       label: 'General',
-      groups: createGeneralTabGroups(element, bpmnFactory, elementRegistry, translate)
+      groups: createGeneralTabGroups(element, bpmnFactory, canvas, elementRegistry, translate)
     };
 
     // The "magic" tab
     var magicTab = {
       id: 'magic',
       label: 'Magic',
-      groups: createMagicTabGroups(element, elementRegistry)
+      groups: createMagicTabGroups(element)
     };
 
     // Show general + "magic" tab

--- a/properties-panel-extension/package.json
+++ b/properties-panel-extension/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "bpmn-js": "^5.0.0-beta.0",
-    "bpmn-js-properties-panel": "^0.30.0",
-    "camunda-bpmn-moddle": "^3.0.0",
+    "bpmn-js-properties-panel": "^0.32.0",
+    "camunda-bpmn-moddle": "^4.0.1",
     "diagram-js": "^3.0.0",
     "jquery": "^3.3.1",
     "min-dash": "^3.0.0"

--- a/properties-panel/package.json
+++ b/properties-panel/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "bpmn-js": "^5.0.0-beta.0",
-    "bpmn-js-properties-panel": "^0.30.0",
-    "camunda-bpmn-moddle": "^3.0.0",
+    "bpmn-js-properties-panel": "^0.32.0",
+    "camunda-bpmn-moddle": "^4.0.1",
     "diagram-js": "^3.3.1",
     "jquery": "^3.4.1",
     "min-dash": "^3.5.0"


### PR DESCRIPTION
This bumps `camunda-bpmn-moddle` + `bpmn-js-properties-panel` dependencies in in the PropertiesPanel and PropertiesPanelExtension example.