### PR TITLE
chore(project): migrate static examples to staticaly

### DIFF
--- a/colors/README.md
+++ b/colors/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to add colors to BPMN diagrams rendered with [bpmn-js](https://github.com/bpmn-io/bpmn-js).
 
-[__Try out__](https://rawgit.com/bpmn-io/bpmn-js-examples/master/colors/index.html).
+[__Try out__](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/colors/index.html).
 
 
 ## About
@@ -131,7 +131,7 @@ Checkout [bpmn-js-task-priorities](https://github.com/bpmn-io/bpmn-js-task-prior
 
 ## Run this Example
 
-Download the [example diagram](https://rawgit.com/bpmn-io/bpmn-js-examples/master/colors/index.html) and open it in a web browser.
+Download the [example diagram](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/colors/index.html) and open it in a web browser.
 
 
 ## License

--- a/colors/index.html
+++ b/colors/index.html
@@ -91,7 +91,7 @@
     }
 
     // load + show diagram
-    $.get('https://cdn.rawgit.com/bpmn-io/bpmn-js-examples/master/colors/resources/pizza-collaboration.bpmn', showDiagram, 'text');
+    $.get('https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/colors/resources/pizza-collaboration.bpmn', showDiagram, 'text');
   </script>
 </body>
 </html>

--- a/custom-bundle/index.html
+++ b/custom-bundle/index.html
@@ -40,7 +40,7 @@
 
     <script>
 
-      var diagramUrl = 'https://cdn.rawgit.com/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
+      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
 
       // viewer instance
       var bpmnViewer = new CustomBpmnJS({

--- a/interaction/README.md
+++ b/interaction/README.md
@@ -3,7 +3,7 @@
 An example that showcases the different ways to enable user interaction with
 BPMN diagrams using [bpmn-js](https://github.com/bpmn-io/bpmn-js).
 
-[__Try out__](https://rawgit.com/bpmn-io/bpmn-js-examples/master/interaction/index.html).
+[__Try out__](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/interaction/index.html).
 
 
 ## About
@@ -88,4 +88,4 @@ handle it accordingly.
 
 ## Run this Example
 
-Download and open the [example HTML page](https://rawgit.com/bpmn-io/bpmn-js-examples/master/interaction/index.html).
+Download and open the [example HTML page](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/interaction/index.html).

--- a/pre-packaged/README.md
+++ b/pre-packaged/README.md
@@ -21,7 +21,7 @@ Download or simply include the relevant dependencies into your website:
 <script src="https://unpkg.com/bpmn-js@5.0.3/dist/bpmn-viewer.development.js"></script>
 ```
 
-Download the complete [viewer example](https://rawgit.com/bpmn-io/bpmn-js-examples/master/starter/viewer.html).
+Download the complete [viewer example](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/starter/viewer.html).
 
 #### Modeler
 
@@ -33,7 +33,7 @@ Download the complete [viewer example](https://rawgit.com/bpmn-io/bpmn-js-exampl
 <script src="https://unpkg.com/bpmn-js@5.0.3/dist/bpmn-modeler.development.js"></script>
 ```
 
-Download the complete [modeler example](https://rawgit.com/bpmn-io/bpmn-js-examples/master/starter/modeler.html).
+Download the complete [modeler example](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/starter/modeler.html).
 
 
 ## Use the Library

--- a/starter/README.md
+++ b/starter/README.md
@@ -1,8 +1,8 @@
 # bpmn-js starter
 
-Try out our toolkit by downloading the [viewer](https://rawgit.com/bpmn-io/bpmn-js-examples/master/starter/viewer.html) or [modeler](https://rawgit.com/bpmn-io/bpmn-js-examples/master/starter/modeler.html) example.
+Try out our toolkit by downloading the [viewer](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/starter/viewer.html) or [modeler](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/starter/modeler.html) example.
 
 
-[![viewer example screenshot](./viewer.png)](https://rawgit.com/bpmn-io/bpmn-js-examples/master/starter/viewer.html)
+[![viewer example screenshot](./viewer.png)](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/starter/viewer.html)
 
-_Screenshot of the [viewer example](https://rawgit.com/bpmn-io/bpmn-js-examples/master/starter/viewer.html)._
+_Screenshot of the [viewer example](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/starter/viewer.html)._

--- a/starter/modeler.html
+++ b/starter/modeler.html
@@ -52,7 +52,7 @@
 
     <script>
 
-      var diagramUrl = 'https://cdn.rawgit.com/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
+      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
 
       // modeler instance
       var bpmnModeler = new BpmnJS({

--- a/starter/viewer.html
+++ b/starter/viewer.html
@@ -45,7 +45,7 @@
 
     <script>
 
-      var diagramUrl = 'https://cdn.rawgit.com/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
+      var diagramUrl = 'https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/dfceecba/starter/diagram.bpmn';
 
       // viewer instance
       var bpmnViewer = new BpmnJS({

--- a/url-viewer/README.md
+++ b/url-viewer/README.md
@@ -3,7 +3,7 @@
 This example uses [bpmn-js](https://github.com/bpmn-io/bpmn-js) to implement a
 simple viewer for BPMN 2.0 process diagrams that can be loaded via their URL.
 
-[__Try out__](https://rawgit.com/bpmn-io/bpmn-js-examples/master/url-viewer/index.html).
+[__Try out__](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/url-viewer/index.html).
 
 
 ## About
@@ -18,4 +18,4 @@ Make sure you serve the application via a web server (nginx, apache, embedded) a
 
 ## Run the Example
 
-Download and open the [example HTML page](https://rawgit.com/bpmn-io/bpmn-js-examples/master/url-viewer/index.html).
+Download and open the [example HTML page](https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/master/url-viewer/index.html).

--- a/url-viewer/index.html
+++ b/url-viewer/index.html
@@ -32,7 +32,7 @@
       <input type="text" id="js-url" placeholder="path to diagram" /><button id="js-open">Open</button>
     </p>
     <p>
-      <strong>Hint:</strong> try <code>https://cdn.rawgit.com/bpmn-io/bpmn-js-examples/dfceecba/url-viewer/resources/pizza-collaboration.bpmn</code></strong>
+      <strong>Hint:</strong> try <code>https://cdn.staticaly.com/gh/bpmn-io/bpmn-js-examples/dfceecba/url-viewer/resources/pizza-collaboration.bpmn</code></strong>
     </p>
   </div>
 


### PR DESCRIPTION
Migrate the static examples from `rawgit` to `staticaly`. This offers a 1:1 replacement for the static file cdn.

Closes #76