### PR TITLE
fix(project): add diagram-js dependency

### DIFF
--- a/properties-panel/package.json
+++ b/properties-panel/package.json
@@ -37,6 +37,7 @@
     "bpmn-js": "^8.2.0",
     "bpmn-js-properties-panel": "^0.38.1",
     "camunda-bpmn-moddle": "^4.0.1",
+    "diagram-js": "^7.2.0",
     "jquery": "^3.5.1",
     "min-dash": "^3.5.2"
   },


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Fixes a bug that the `npm run all` will not work:
```
ERROR in ./node_modules/diagram-js-direct-editing/index.js 1:0-81
Module not found: Error: Can't resolve 'diagram-js/lib/features/interaction-events' in '/home/maxtru/Dokumente/10_modules/bpmn-io/bpmn-js-examples/properties-panel/node_modules/diagram-js-direct-editing'
 @ ./node_modules/bpmn-js/lib/features/context-pad/index.js 1:0-60 12:4-23
 @ ./node_modules/bpmn-js/lib/Modeler.js 20:0-54 190:2-18
 @ ./src/app.js 2:0-46 17:22-33

```

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/.github/blob/master/.github/CONTRIBUTING.md#create-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
