### PR TITLE
docs(properties-panel): import path

### DIFF
--- a/properties-panel/README.md
+++ b/properties-panel/README.md
@@ -87,7 +87,7 @@ import {
   CamundaPlatformPropertiesProviderModule
 } from 'bpmn-js-properties-panel';
 
-import CamundaBpmnModdle from 'camunda-bpmn-moddle/resources/zeebe.json'
+import CamundaBpmnModdle from 'camunda-bpmn-moddle/resources/camunda.json'
 
 const bpmnModeler = new BpmnModeler({
   container: '#js-canvas',


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

From https://github.com/camunda/camunda-bpmn-moddle/tree/v6.1.1/resources, this import path should be `camunda.json` rather than `zeebe.json`.