### PR TITLE
Fix babelify dependency

### DIFF
--- a/commenting/package.json
+++ b/commenting/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "babelify": "^10.0.0",
+    "babelify": "^8.0.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^6.0.0",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
Following `commenting/README.md` and running `npm run dev` fails with

```
babelify@10 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babelify@8'.
```

Using ` "babelify": "^8.0.0",` instead fixes the issue.