### PR TITLE
Add missing copy-webpack-plugin dependency to bundling example

### DIFF
--- a/bundling/package.json
+++ b/bundling/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.19.0",
     "@babel/preset-env": "^7.19.0",
     "babel-loader": "^9.0.0",
-    "copy-webpack-plugin": "^12.0.2"
+    "copy-webpack-plugin": "^12.0.2",
     "npm-run-all2": "^6.0.0",
     "open-cli": "^8.0.0",
     "webpack": "^5.74.0",

--- a/bundling/package.json
+++ b/bundling/package.json
@@ -35,7 +35,8 @@
     "npm-run-all2": "^6.0.0",
     "open-cli": "^8.0.0",
     "webpack": "^5.74.0",
-    "webpack-cli": "^5.0.0"
+    "webpack-cli": "^5.0.0",
+    "copy-webpack-plugin": "^12.0.2"
   },
   "dependencies": {
     "bpmn-js": "^17.9.0"

--- a/bundling/package.json
+++ b/bundling/package.json
@@ -32,11 +32,11 @@
     "@babel/core": "^7.19.0",
     "@babel/preset-env": "^7.19.0",
     "babel-loader": "^9.0.0",
+    "copy-webpack-plugin": "^12.0.2"
     "npm-run-all2": "^6.0.0",
     "open-cli": "^8.0.0",
     "webpack": "^5.74.0",
-    "webpack-cli": "^5.0.0",
-    "copy-webpack-plugin": "^12.0.2"
+    "webpack-cli": "^5.0.0"
   },
   "dependencies": {
     "bpmn-js": "^17.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "@babel/core": "^7.19.0",
         "@babel/preset-env": "^7.19.0",
         "babel-loader": "^9.0.0",
+        "copy-webpack-plugin": "^12.0.2",
         "npm-run-all2": "^6.0.0",
         "open-cli": "^8.0.0",
         "webpack": "^5.74.0",
@@ -8226,10 +8227,11 @@
       }
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.0.tgz",
-      "integrity": "sha512-WQfxZKgoRB94/g0BP/cjADvE6jXQKoSk0lFFeIC5HZlE1JuabYPwhQUtOZsGI0cI+QMsi6vhdIDy4eNXKcTgFg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.1",


### PR DESCRIPTION
### Proposed Changes

- Add missing dev dependency for webpack-copy-plugin to bundling example

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached - (not applicable)
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr) - (not applicable)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}` - (not applicable)