### PR TITLE
fix: add missing diagram-js stylesheet to examples

### DIFF
--- a/bundling/src/index.html
+++ b/bundling/src/index.html
@@ -13,7 +13,8 @@
   </style>
 
   <!-- required viewer styles -->
-  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@15.0.1/dist/assets/bpmn-js.css">
+  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css">
+  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css">
 
   <!--
     this is an example of how to use bpmn-js in a standalone application built with

--- a/custom-bundle/index.html
+++ b/custom-bundle/index.html
@@ -11,6 +11,7 @@
     <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>
 
     <!-- required viewer styles -->
+    <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css">
     <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css">
 
     <!-- example styles -->

--- a/overlays/src/index.html
+++ b/overlays/src/index.html
@@ -6,7 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
   <!-- required viewer styles -->
-  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@9.0.1/dist/assets/bpmn-js.css">
+  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css">
+  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css">
 
   <style type="text/css">
     html, body, #canvas {

--- a/pre-packaged/README.md
+++ b/pre-packaged/README.md
@@ -19,6 +19,7 @@ Download or simply include the relevant dependencies into your website:
 
 ```html
 <!-- required viewer styles -->
+<link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css" />
 <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css" />
 
 <script src="https://unpkg.com/bpmn-js@17.11.1/dist/bpmn-viewer.development.js"></script>

--- a/starter/viewer.html
+++ b/starter/viewer.html
@@ -10,6 +10,7 @@
     -->
 
     <!-- required viewer styles -->
+    <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css">
     <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css">
 
     <!-- viewer distro (with pan and zoom) -->

--- a/theming/index.html
+++ b/theming/index.html
@@ -5,6 +5,7 @@
     <title>bpmn-js Theming</title>
 
     <!-- required viewer styles -->
+    <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css">
     <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css">
 
     <!-- viewer distro -->

--- a/url-viewer/index.html
+++ b/url-viewer/index.html
@@ -3,6 +3,7 @@
   <title>bpmn-js url viewer demo</title>
 
   <!-- required viewer styles -->
+  <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/diagram-js.css">
   <link rel="stylesheet" href="https://unpkg.com/bpmn-js@17.11.1/dist/assets/bpmn-js.css">
 
   <style>


### PR DESCRIPTION
related to https://github.com/bpmn-io/bpmn-js/issues/2135

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

There were missing `diagram-js.css` imports missing in some of the examples, which caused for example no indication of selected items and in case of multi-selection - the selected elements were covered by a black rectangle (see the related issue for a GIF)

To try out the solution, simply open any example which and see that selected elements are properly indicated

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
